### PR TITLE
add ENV PATH so downstream Dockerfiles can expect to find anaconda binaries in PATH

### DIFF
--- a/miniconda/Dockerfile
+++ b/miniconda/Dockerfile
@@ -7,3 +7,4 @@ RUN echo 'export PATH=/opt/anaconda/bin:$PATH' > /etc/profile.d/conda.sh
 RUN wget --quiet http://repo.continuum.io/miniconda/Miniconda3-3.6.0-Linux-x86_64.sh && \
     /bin/bash /Miniconda3-3.6.0-Linux-x86_64.sh -b -p /opt/anaconda && \
     rm Miniconda3-3.6.0-Linux-x86_64.sh
+ENV PATH /opt/anaconda/bin:$PATH


### PR DESCRIPTION
Hi!

I'm new to Docker.  Please forgive me if I'm missing something here.  What do you think about adding the following line to the Dockerfile?

```
ENV PATH /opt/anaconda/bin:$PATH
```

My reasoning for this is that if decide to have my app inherit `FROM continuumio/miniconda` in a separate Dockerfile, I see that conda and python binaries are not immediately available in the PATH without first initializing a login shell.  

For instance, shouldn't

```
 $ docker run continuumio/miniconda env | grep PATH
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

be the same as this?

```
 $ docker run continuumio/miniconda bash -lc 'env' | grep PATH
PATH=/opt/anaconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

This pull request results in:

```
 $ docker run adgaudio/miniconda env | grep PATH
PATH=/opt/anaconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```
