### PR TITLE
Run Jupyter with ip 0.0.0.0 instead of '*'

### DIFF
--- a/miniconda3/README.md
+++ b/miniconda3/README.md
@@ -16,6 +16,6 @@ You can download and run this image using the following commands:
 
 Alternatively, you can start a Jupyter Notebook server and interact with Miniconda via your browser:
 
-    docker run -i -t -p 8888:8888 continuumio/miniconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+    docker run -i -t -p 8888:8888 continuumio/miniconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='0.0.0.0' --port=8888 --no-browser"
 
 You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.


### PR DESCRIPTION
The current run instructions use `--ip='*'` but this does not work with newer Docker installations (you get multiple errors in the run output and the Jupiter server ultimately does not start). 

Changing to `--ip='0.0.0.0'` instead.