### PR TITLE
Disable pkg-build image builds

### DIFF
--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -1,17 +1,17 @@
 name: Build and publish Linux package builder images
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'pkg-build-*'
-    paths:
-      - 'anaconda-pkg-build/linux/Dockerfile'
-      - '.github/workflows/anaconda_pkg_build_linux.yml'
-  pull_request:
-    paths:
-      - 'anaconda-pkg-build/linux/Dockerfile'
-      - '.github/workflows/anaconda_pkg_build_linux.yml'
+  #push:
+  #  branches:
+  #    - main
+  #  tags:
+  #    - 'pkg-build-*'
+  #  paths:
+  #    - 'anaconda-pkg-build/linux/Dockerfile'
+  #    - '.github/workflows/anaconda_pkg_build_linux.yml'
+  #pull_request:
+  #  paths:
+  #    - 'anaconda-pkg-build/linux/Dockerfile'
+  #    - '.github/workflows/anaconda_pkg_build_linux.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -1,17 +1,17 @@
 name: Build and publish Linux CUDA package builder images
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'pkg-build-*'
-    paths:
-      - 'anaconda-pkg-build/linux/cuda/Dockerfile'
-      - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
-  pull_request:
-    paths:
-      - 'anaconda-pkg-build/linux/cuda/Dockerfile'
-      - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
+  #push:
+  #  branches:
+  #    - main
+  #  tags:
+  #    - 'pkg-build-*'
+  #  paths:
+  #    - 'anaconda-pkg-build/linux/cuda/Dockerfile'
+  #    - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
+  #pull_request:
+  #  paths:
+  #    - 'anaconda-pkg-build/linux/cuda/Dockerfile'
+  #    - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Since these images keep failing to build due to CentOS 7 being EOL, disable them until a solution has been found by the package building team(s).