### PR TITLE
Use QEMU v8.1.5

### DIFF
--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
         with:
+          # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+          image: tonistiigi/binfmt:qemu-v8.1.5
           platforms: linux/arm64/v8
 
       - name: Set up Docker Buildx

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
         with:
+          # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+          image: tonistiigi/binfmt:qemu-v8.1.5
           platforms: linux/amd64,linux/arm64/v8,linux/s390x
 
       - name: Set up Docker Buildx

--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+        with:
+          # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+        with:
+          # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
         with:
+          # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+          image: tonistiigi/binfmt:qemu-v8.1.5
           platforms: linux/amd64,linux/arm64,linux/s390x
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
The Amazon Linux builds appear to have random seg faults and other errors when installing dependencies. A possible cause is the `setup-qemu` action because it uses v7 instead of v8.