### PR TITLE
Constrain conda build to a version which builds tarballs by default

### DIFF
--- a/anaconda-pkg-build/linux/alma/Dockerfile
+++ b/anaconda-pkg-build/linux/alma/Dockerfile
@@ -77,7 +77,7 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 # renovate: datasource=custom.miniconda_installer depName=Linux-x86_64.sh
-ARG INSTALLER_VERSION=py312_25.1.1-2
+ARG INSTALLER_VERSION=py312_24.5.0-0
 
 RUN curl -sSL -o /tmp/miniconda.sh \
         "https://repo.anaconda.com/miniconda/Miniconda3-${INSTALLER_VERSION}-Linux-$(uname -m)".sh \
@@ -87,10 +87,12 @@ RUN curl -sSL -o /tmp/miniconda.sh \
     # ensure there are no out of range userids
     && chown -R root:root /opt/conda
 
+# anaconda-telemetry conflicts with conda-build 24.1.2
 # hadolint ignore=DL3059
 RUN MC_ARCH="$(uname -m)" \
     && if [ "${MC_ARCH}" = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
     && /opt/conda/bin/conda update --all --quiet --yes \
+    #&& /opt/conda/bin/conda uninstall --quiet --yes conda-anaconda-telemetry \
     && /opt/conda/bin/conda install --quiet --yes conda-build=24.1.2 \
     && /opt/conda/bin/conda clean --all --yes \
     && rm -fv /opt/conda/.condarc \

--- a/anaconda-pkg-build/linux/alma/Dockerfile
+++ b/anaconda-pkg-build/linux/alma/Dockerfile
@@ -91,7 +91,7 @@ RUN curl -sSL -o /tmp/miniconda.sh \
 RUN MC_ARCH="$(uname -m)" \
     && if [ "${MC_ARCH}" = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
     && /opt/conda/bin/conda update --all --quiet --yes \
-    && /opt/conda/bin/conda install --quiet --yes conda-build \
+    && /opt/conda/bin/conda install --quiet --yes conda-build=24.1.2 \
     && /opt/conda/bin/conda clean --all --yes \
     && rm -fv /opt/conda/.condarc \
     && /opt/conda/bin/conda config --system --set show_channel_urls True \


### PR DESCRIPTION
This change impacts on Anaconda's CI, which currently assumes that the docker container's conda-build builds tarballs.

Here's the versions of conda-related packages in this container:
```
anaconda-anon-usage       0.5.0           py312hfc0e8ea_100    defaults
conda                     24.1.2          py312h06a4308_0    defaults
conda-build               24.1.2          py312h06a4308_0    defaults
conda-content-trust       0.2.0           py312h06a4308_1    defaults
conda-index               0.5.0           py312h06a4308_0    defaults
conda-libmamba-solver     25.1.1             pyhd3eb1b0_0    defaults
conda-package-handling    2.4.0           py312h06a4308_0    defaults
conda-package-streaming   0.11.0          py312h06a4308_0    defaults
```

here are the ones in the existing (main) build container

```
conda                     24.1.2           py39h06a4308_0    defaults
conda-build               24.1.2           py39h06a4308_0    defaults
conda-content-trust       0.2.0            py39h06a4308_0    defaults
conda-index               0.4.0              pyhd3eb1b0_0    defaults
conda-libmamba-solver     24.1.0             pyhd3eb1b0_0    defaults
conda-package-handling    2.2.0            py39h06a4308_0    defaults
conda-package-streaming   0.9.0            py39h06a4308_0    defaults
```