### PR TITLE
Add github workflow to upload rocky 8 image for building

### DIFF
--- a/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
@@ -1,0 +1,76 @@
+name: Build and publish Linux CUDA package builder images
+on:
+  #push:
+  #  branches:
+  #    - main
+  #  tags:
+  #    - 'pkg-build-*'
+  #  paths:
+  #    - 'anaconda-pkg-build/linux/cuda-rocky8/Dockerfile'
+  #    - '.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml'
+  #pull_request:
+  #  paths:
+  #    - 'anaconda-pkg-build/linux/cuda-rocky8/Dockerfile'
+  #    - '.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Public ECR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+          image: tonistiigi/binfmt:qemu-v8.1.5
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          version: latest
+          driver-opts: network=host
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            continuumio/anaconda-pkg-build
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tags: |
+            type=ref,event=branch,suffix=-cuda-rocky8
+            type=ref,event=pr,suffix=-cuda-rocky8
+            type=match,pattern=pkg-build-(.*),group=1,suffix=-cuda-rocky8
+
+      - name: build-push pkg-builder
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: ./anaconda-pkg-build/linux/cuda-rocky8
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/cuda-rocky8/Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            CUDA_VERSION=11.8.0
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
Adds workflow to upload the [previously merged](https://github.com/anaconda/docker-images/pull/635) cuda rocky 8 docker container