### PR TITLE
Harden build actions

### DIFF
--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
           platforms: linux/arm64/v8
 
       - name: Set up Docker Buildx

--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/anaconda_amazonlinux_ci.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -42,9 +42,10 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          cache-binary: false
+          driver-opts: network=host
           # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
-          driver-opts: network=host
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -42,7 +42,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
+          version: v0.23.0
           driver-opts: network=host
 
       - name: Docker meta

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
           platforms: linux/amd64,linux/arm64/v8,linux/s390x
 
       - name: Set up Docker Buildx

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/anaconda_debian_ci.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -42,9 +42,10 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          cache-binary: false
+          driver-opts: network=host
           # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
-          driver-opts: network=host
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -42,7 +42,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
+          version: v0.23.0
           driver-opts: network=host
 
       - name: Docker meta

--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -14,6 +14,8 @@ on:
   #    - '.github/workflows/anaconda_pkg_build_linux.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -51,9 +51,10 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          cache-binary: false
+          driver-opts: network=host
           # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
-          driver-opts: network=host
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -51,7 +51,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
+          version: v0.23.0
           driver-opts: network=host
 
       - name: Docker meta

--- a/.github/workflows/anaconda_pkg_build_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_linux.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/anaconda_pkg_build_linux_alma.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_alma.yml
@@ -51,9 +51,10 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          cache-binary: false
+          driver-opts: network=host
           # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
-          driver-opts: network=host
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/anaconda_pkg_build_linux_alma.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_alma.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/anaconda_pkg_build_linux_alma.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_alma.yml
@@ -51,7 +51,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
+          version: v0.23.0
           driver-opts: network=host
 
       - name: Docker meta

--- a/.github/workflows/anaconda_pkg_build_linux_alma.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_alma.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/anaconda_pkg_build_linux_alma.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_alma.yml
@@ -14,6 +14,8 @@ on:
   #     - '.github/workflows/anaconda_pkg_build_linux_alma.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -51,9 +51,10 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          cache-binary: false
+          driver-opts: network=host
           # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
-          driver-opts: network=host
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -51,7 +51,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
+          version: v0.23.0
           driver-opts: network=host
 
       - name: Docker meta

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -14,6 +14,8 @@ on:
   #    - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
@@ -51,9 +51,10 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          cache-binary: false
+          driver-opts: network=host
           # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
-          driver-opts: network=host
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
@@ -51,7 +51,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
+          version: v0.23.0
           driver-opts: network=host
 
       - name: Docker meta

--- a/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
@@ -14,6 +14,8 @@ on:
      - '.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda_rocky8.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -42,8 +42,9 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # renovate: datasource=github-releases depName=docker/buildx
+          cache-binary: false
           driver-opts: network=host
+          # renovate: datasource=github-releases depName=docker/buildx
           version: v0.23.0
 
       - name: Docker meta

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -42,8 +42,9 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=docker/buildx
           driver-opts: network=host
+          version: v0.23.0
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/miniconda_debian_ci.yml'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Harden the GitHub Actions that build the Docker images by

* restricting permissions of each workflow
* pinning the QEMU image to the hash
* disabling persisting permissions
* disabling caching the buildx binary to prevent cache poisoning
* pinning the buildx version.