### PR TITLE
Add Dockerfiles to test tag compatibility with renovate

### DIFF
--- a/test/renovate/Dockerfile_miniconda3
+++ b/test/renovate/Dockerfile_miniconda3
@@ -1,0 +1,3 @@
+FROM continuumio/miniconda3:25.1.1-0
+
+RUN ls


### PR DESCRIPTION
This should trigger a renovate update every time we release a new version to prove that renovate auto discover works by default with miniconda3 tag format.

The added Dockerfile is named according to https://docs.renovatebot.com/modules/manager/dockerfile/#default-config and has an older version as initial check.