### PR TITLE
Create Miniconda and Anadonda Distribution tags without build number

### DIFF
--- a/.github/workflows/anaconda_amazonlinux_ci.yml
+++ b/.github/workflows/anaconda_amazonlinux_ci.yml
@@ -51,6 +51,7 @@ jobs:
             type=ref,event=branch,suffix=-amazonlinux
             type=ref,event=pr,suffix=-amazonlinux
             type=match,pattern=anaconda3-(.*),group=1,suffix=-amazonlinux
+            type=match,pattern=anaconda3-(.*)-(.*),group=1,suffix=-amazonlinux
           flavor: |
             latest=false
 

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -51,6 +51,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=match,pattern=anaconda3-(.*),group=1
+            type=match,pattern=anaconda3-(.*)-(.*),group=1,suffix=-amazonlinux
 
       - name: build-push anaconda3/debian
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -50,6 +50,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=match,pattern=miniconda3-(.*),group=1
+            type=match,pattern=miniconda3-(.*)-(.*),group=1
 
       - name: build miniconda3/debian
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0


### PR DESCRIPTION
Docker tags with build numbers are, by default, not compatible with `renovate`. The build numbers are not always consecutive either since not all builds are published. Providing tags that are independent of build number allows for an easier update and maintenance experience.