### PR TITLE
Disable automatic conda update for Miniconda

### DIFF
--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -54,4 +54,5 @@ RUN set -x && \
     echo "conda activate" >> ~/.bashrc && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy
+    /opt/conda/bin/conda clean -afy && \
+    /opt/conda/bin/conda config --set auto_update_conda False


### PR DESCRIPTION
When using Miniconda images, users expect a specific `conda` version. However, `conda` defaults to automatically update `conda` when installing a new package, causing a mismatch between Docker tag and `conda` version.

Disable automatically updating `conda` for Miniconda Docker images. Closes #660.