### PR TITLE
Add package format to .condarc

### DIFF
--- a/anaconda-pkg-build/linux/rocky8/Dockerfile
+++ b/anaconda-pkg-build/linux/rocky8/Dockerfile
@@ -61,8 +61,11 @@ RUN MC_ARCH="$(uname -m)" \
     && /opt/conda/bin/conda install --quiet --yes conda-build \
     && /opt/conda/bin/conda clean --all --yes \
     && rm -fv /opt/conda/.condarc \
+    && /opt/conda/bin/conda config --system --add channels defaults \
     && /opt/conda/bin/conda config --system --set show_channel_urls True \
     && /opt/conda/bin/conda config --system --set add_pip_as_python_dependency False \
+    && /opt/conda/bin/conda config --system --set report_errors False \
+    && /opt/conda/bin/conda config --system --set conda_build.pkg_format ".tar.bz2" \
     && /opt/conda/bin/conda config --show-sources \
     # Cache our C and C++ compilers so we don't have to download them with
     # each build; skipping the Fortran compiler as it's not used often


### PR DESCRIPTION
Updated conda configuration to include `defaults` channel, turn off error reporting, and ensure package format stays `.tar.bz2`.