### PR TITLE
Deprecate `continuumio/miniconda3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Anaconda and Miniconda Docker Images and Documentation
 
+>[!CAUTION]
+>The `continuumio` images are deprecated. Updates to `continuumio/miniconda3` will be
+>discontinued after version `25.7.x`. The latest Docker images for Miniconda are
+>available at [`anaconda/miniconda`](https://hub.docker.com/r/anaconda/miniconda).
+
 Docker images for Anaconda/Miniconda that are available from DockerHub:
 
 https://hub.docker.com/r/continuumio/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >[!CAUTION]
 >The `continuumio` images are deprecated. Updates to `continuumio/miniconda3` will be
->discontinued after version `25.7.x`. The latest Docker images for Miniconda are
+>discontinued after version `26.7.x`. The latest Docker images for Miniconda are
 >available at [`anaconda/miniconda`](https://hub.docker.com/r/anaconda/miniconda).
 
 Docker images for Anaconda/Miniconda that are available from DockerHub:

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -24,6 +24,18 @@ RUN apt-get update -q && \
 
 ENV PATH=/opt/conda/bin:$PATH
 
+ARG DEPRECATION_MESSAGE="::warning::This image is deprecated.\n\n\
+Updates to this image will be discontinued after version \`25.7.x\`. \
+The latest Miniconda Docker images are available as \`anaconda/miniconda\`. \
+For more information, visit: https://hub.docker.com/r/anaconda/miniconda"
+
+# Deprecation warning script
+RUN echo '#!/bin/bash\n\
+echo "'"${DEPRECATION_MESSAGE}"'" >&2\n\
+exec "$@"' > /usr/local/bin/docker-entrypoint.sh && \
+    chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD [ "/bin/bash" ]
 
 # Leave these args here to better use the Docker build cache

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -q && \
 ENV PATH=/opt/conda/bin:$PATH
 
 ARG DEPRECATION_MESSAGE="::warning::This image is deprecated.\n\n\
-Updates to this image will be discontinued after version \`25.7.x\`. \
+Updates to this image will be discontinued after version \`26.7.x\`. \
 The latest Miniconda Docker images are available as \`anaconda/miniconda\`. \
 For more information, visit: https://hub.docker.com/r/anaconda/miniconda\n"
 

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -27,12 +27,11 @@ ENV PATH=/opt/conda/bin:$PATH
 ARG DEPRECATION_MESSAGE="::warning::This image is deprecated.\n\n\
 Updates to this image will be discontinued after version \`25.7.x\`. \
 The latest Miniconda Docker images are available as \`anaconda/miniconda\`. \
-For more information, visit: https://hub.docker.com/r/anaconda/miniconda"
+For more information, visit: https://hub.docker.com/r/anaconda/miniconda\n"
 
 # Deprecation warning script
-RUN echo '#!/bin/bash\n\
-echo "'"${DEPRECATION_MESSAGE}"'" >&2\n\
-exec "$@"' > /usr/local/bin/docker-entrypoint.sh && \
+RUN printf '#!/bin/bash\nprintf "'%s'" >&2\nexec "$@"\n' "${DEPRECATION_MESSAGE}" \
+    > /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
The `continuumio` DockerHub organization is slated for deprecation. Miniconda Docker images will be updated there until version `26.7.x`. For further updates, the [`anaconda/miniconda`](https://hub.docker.com/r/anaconda/miniconda) repository is to be used.

Add a deprecation notice to the Docker image to display in interactive and non-interactive runs.