### PR TITLE
Clarify that the Miniconda Docker image deprecation refers to the Miniconda version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >[!CAUTION]
 >The `continuumio` images are deprecated. Updates to `continuumio/miniconda3` will be
->discontinued after version `26.7.x`. The latest Docker images for Miniconda are
+>discontinued after Miniconda version `26.7.x`. The latest Docker images for Miniconda are
 >available at [`anaconda/miniconda`](https://hub.docker.com/r/anaconda/miniconda).
 
 Docker images for Anaconda/Miniconda that are available from DockerHub:

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -q && \
 ENV PATH=/opt/conda/bin:$PATH
 
 ARG DEPRECATION_MESSAGE="::warning::This image is deprecated.\n\n\
-Updates to this image will be discontinued after version \`26.7.x\`. \
+Updates to this image will be discontinued after Miniconda version \`26.7.x\`. \
 The latest Miniconda Docker images are available as \`anaconda/miniconda\`. \
 For more information, visit: https://hub.docker.com/r/anaconda/miniconda\n"
 


### PR DESCRIPTION
There has been some confusion about which version the deprecation message has been referring to. Clarify that the deprecation message refers to the version of Miniconda.